### PR TITLE
joyent/node-triton-netconfig #3 want isNetTagged()/isNicTagged() for arbitrary nic tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 (nothing yet)
 
+## 1.5.0
+
+* [#3] want isNetTagged()/isNicTagged() for arbitrary nic tags
+
 ## 1.4.0
 
 * TRITON-1667 Want isNicManta and isNetManta functions in node-triton-netconfig

--- a/lib/index.js
+++ b/lib/index.js
@@ -201,6 +201,10 @@ function isNicManta(nic) {
     return _isNetNicCommon(nic, MANTA_NAME);
 }
 
+function isNicTagged(nic, tag) {
+    return _isNetNicCommon(nic, tag);
+}
+
 // ---- isNet
 
 function isNetAdmin(net) {
@@ -213,6 +217,10 @@ function isNetExternal(net) {
 
 function isNetInternal(net) {
     return _isNetCommon(net, INTERNAL_NAME);
+}
+
+function isNetTagged(net, tag) {
+    return _isNetCommon(net, tag);
 }
 
 function isNetManta(net) {
@@ -231,8 +239,10 @@ module.exports = {
     isNicAdmin: isNicAdmin,
     isNicExternal: isNicExternal,
     isNicManta: isNicManta,
+    isNicTagged: isNicTagged,
     isNetAdmin: isNetAdmin,
     isNetExternal: isNetExternal,
     isNetInternal: isNetInternal,
-    isNetManta: isNetManta
+    isNetManta: isNetManta,
+    isNetTagged: isNetTagged
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triton-netconfig",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Common methods for managing Triton network configuration",
   "repository": {
     "type": "git",

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -25,6 +25,7 @@ tap.test('nets', function (tt) {
         const admin_net = NETS['admin_mainnet'];
         const external_net = NETS['external_mainnet'];
         const manta_net = NETS['manta_mainnet'];
+        const foobar_net = NETS['foobar_mainnet'];
 
         t.ok(netconf.isNetAdmin(admin_net));
         t.notOk(netconf.isNetExternal(admin_net));
@@ -37,6 +38,13 @@ tap.test('nets', function (tt) {
         t.ok(netconf.isNetManta(manta_net));
         t.notOk(netconf.isNetAdmin(manta_net));
         t.notOk(netconf.isNetExternal(manta_net));
+
+        t.ok(netconf.isNetTagged(manta_net, 'manta'));
+        t.notOk(netconf.isNetTagged(manta_net, 'foobar'));
+        t.ok(netconf.isNetTagged(foobar_net, 'foobar'));
+        t.notOk(netconf.isNetAdmin(foobar_net));
+        t.notOk(netconf.isNetManta(foobar_net));
+        t.notOk(netconf.isNetExternal(foobar_net));
 
         t.end();
     });
@@ -45,6 +53,7 @@ tap.test('nets', function (tt) {
         const admin_net = NETS['admin_racknet'];
         const external_net = NETS['external_racknet'];
         const manta_net = NETS['manta_racknet'];
+        const foobar_net = NETS['foobar_racknet'];
 
         t.ok(netconf.isNetAdmin(admin_net));
         t.notOk(netconf.isNetExternal(admin_net));
@@ -57,6 +66,13 @@ tap.test('nets', function (tt) {
         t.ok(netconf.isNetManta(manta_net));
         t.notOk(netconf.isNetAdmin(manta_net));
         t.notOk(netconf.isNetExternal(manta_net));
+
+        t.ok(netconf.isNetTagged(manta_net, 'manta'));
+        t.notOk(netconf.isNetTagged(manta_net, 'foobar'));
+        t.ok(netconf.isNetTagged(foobar_net, 'foobar'));
+        t.notOk(netconf.isNetAdmin(foobar_net));
+        t.notOk(netconf.isNetManta(foobar_net));
+        t.notOk(netconf.isNetExternal(foobar_net));
 
         t.end();
     });
@@ -138,10 +154,11 @@ tap.test('vms', function (tt) {
 
 tap.test('nics', function (tt) {
     tt.test('main', function (t) {
-        const main_vm = VMS['rack'];
+        const main_vm = VMS['main'];
         const external_nic = main_vm['nics'][0];
         const manta_nic = main_vm['nics'][1];
         const admin_nic = main_vm['nics'][2];
+        const foobar_nic = main_vm['nics'][3];
 
         t.ok(netconf.isNicAdmin(admin_nic));
         t.notOk(netconf.isNicExternal(admin_nic));
@@ -154,6 +171,11 @@ tap.test('nics', function (tt) {
         t.ok(netconf.isNicManta(manta_nic));
         t.notOk(netconf.isNicAdmin(manta_nic));
         t.notOk(netconf.isNicExternal(manta_nic));
+
+        t.notOk(netconf.isNicManta(foobar_nic));
+        t.notOk(netconf.isNicAdmin(foobar_nic));
+        t.notOk(netconf.isNicExternal(foobar_nic));
+        t.ok(netconf.isNicTagged(foobar_nic, 'foobar'));
 
         t.end();
     });
@@ -162,6 +184,7 @@ tap.test('nics', function (tt) {
         const external_nic = rack_vm['nics'][0];
         const manta_nic = rack_vm['nics'][1];
         const admin_nic = rack_vm['nics'][2];
+        const foobar_nic = rack_vm['nics'][3];
 
         t.ok(netconf.isNicAdmin(admin_nic));
         t.notOk(netconf.isNicExternal(admin_nic));
@@ -174,6 +197,11 @@ tap.test('nics', function (tt) {
         t.ok(netconf.isNicManta(manta_nic));
         t.notOk(netconf.isNicAdmin(manta_nic));
         t.notOk(netconf.isNicExternal(manta_nic));
+
+        t.notOk(netconf.isNicManta(foobar_nic));
+        t.notOk(netconf.isNicAdmin(foobar_nic));
+        t.notOk(netconf.isNicExternal(foobar_nic));
+        t.ok(netconf.isNicTagged(foobar_nic, 'foobar'));
 
         t.end();
     });

--- a/test/unit/testdata.json
+++ b/test/unit/testdata.json
@@ -69,6 +69,19 @@
                 ],
                 "network_uuid": "0a4d08a1-8e7f-48aa-9a68-91bdf2edd93e",
                 "mtu": 1500
+              },
+              {
+                "interface": "net3",
+                "mac": "90:b8:d0:13:aa:f0",
+                "vlan_id": 0,
+                "nic_tag": "foobar",
+                "netmask": "255.255.255.0",
+                "ip": "1.2.3.11",
+                "ips": [
+                  "1.2.3.11/24"
+                ],
+                "network_uuid": "86070487-ee4b-4f48-8955-1d378c862827",
+                "mtu": 1500
               }
             ],
             "owner_uuid": "58a49944-2b28-65ed-8992-dfa301152a67",
@@ -165,6 +178,19 @@
                   "10.222.222.13/24"
                 ],
                 "network_uuid": "ef5461db-7a70-4920-b6fb-e5c4b9918de2",
+                "mtu": 1500
+              },
+              {
+                "interface": "net3",
+                "mac": "90:b8:d0:13:ae:01",
+                "vlan_id": 0,
+                "nic_tag": "foobar_rack_f11",
+                "netmask": "255.255.255.0",
+                "ip": "1.2.4.11",
+                "ips": [
+                  "1.2.4.11/24"
+                ],
+                "network_uuid": "4268cefc-74d4-4776-becd-f98dad32c367",
                 "mtu": 1500
               }
             ],
@@ -741,6 +767,42 @@
             "resolvers": [],
             "routes": {
                 "192.168.222.0/24": "192.168.100.1"
+            },
+            "owner_uuids": [
+                "4d649f41-cf87-ca1d-c2c0-bb6a9004311d"
+            ],
+            "netmask": "255.255.255.0"
+        },
+        "foobar_mainnet": {
+            "family": "ipv4",
+            "mtu": 1500,
+            "nic_tag": "foobar",
+            "name": "foobar",
+            "provision_end_ip": "1.2.3.254",
+            "provision_start_ip": "1.2.3.10",
+            "subnet": "1.2.3.0/24",
+            "uuid": "86070487-ee4b-4f48-8955-1d378c862827",
+            "vlan_id": 0,
+            "resolvers": [],
+            "routes": {},
+            "owner_uuids": [
+              "4d649f41-cf87-ca1d-c2c0-bb6a9004311d",
+              "930896af-bf8c-48d4-885c-6573a94b1853"
+            ],
+            "netmask": "255.255.255.0"
+        },
+        "foobar_racknet": {
+            "family": "ipv4",
+            "mtu": 1500,
+            "nic_tag": "foobar_rack_f11",
+            "name": "foobar_rack_f11",
+            "provision_end_ip": "1.2.4.254",
+            "provision_start_ip": "1.2.4.10",
+            "subnet": "1.2.4.0/24",
+            "uuid": "4268cefc-74d4-4776-becd-f98dad32c367",
+            "vlan_id": 0,
+            "resolvers": [],
+            "routes": {
             },
             "owner_uuids": [
                 "4d649f41-cf87-ca1d-c2c0-bb6a9004311d"


### PR DESCRIPTION
Testing done:
 * `make check`
 * `node ./test/unit/main.test.js`
 * Used as part of a cloudapi change to use this for additional "external" nets